### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/web/debian/Dockerfile
+++ b/docker/web/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:apache
+FROM php:8.1-apache
 
 WORKDIR /etc/apache2
 


### PR DESCRIPTION
apacheのベースイメージをphp:8.1-apacheに固定しました。
mtの最大動作確認バージョンです。